### PR TITLE
add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.yml]
+indent_size = 2
+
+[*.py]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
# 概要
プロジェクトないのソースコード、CI/CD 用の設定ファイル等の文字コード・インデントスタイル等の統一のために .editorconfig ファイルを追加。主な運用ルールは下記の通り。

* 文字コードは UTF-8
* Python のインデントスタイルはタブ、それ以外はスペースを基本とする
* インデント幅は 2
* 改行コードは LF
* 末尾の空白は除く（ただし、Markdown では意味があるので除く）