### PR TITLE
エラーメッセージに含まれる環境変数名を修正

### DIFF
--- a/noct/cli.py
+++ b/noct/cli.py
@@ -18,7 +18,7 @@ def cmd():
 @click.option('--buttons', multiple=True)
 def slack_cmd(url, channel, title, username, icon_emoji, alert, buttons):
 	if url is None:
-		raise click.BadOptionUsage('url', 'to pulish slack message, url option or SLACK_URL environment variable is required')
+		raise click.BadOptionUsage('url', 'to pulish slack message, url option or SLACK_WEBHOOK_URL environment variable is required')
 	#
 	# SLACK 通知用 BASE JSON生成
 	#


### PR DESCRIPTION
表題の通りタイポの修正です

誤： `SLACK_URL`  
正： `SLACK_WEBHOOK_URL`